### PR TITLE
Fix infinite reload for playlists with privated/deleted videos.

### DIFF
--- a/content.js
+++ b/content.js
@@ -65,7 +65,7 @@ function pollPlaylistReady() {
 
       if (playlistLength > 100 && videos.length >= 100) {
         createDurationElement(videos);
-      } else if (videos.length === playlistLength) {
+      } else if (videos.length === playableLength) {
         createDurationElement(videos);
       }
 

--- a/content.js
+++ b/content.js
@@ -55,7 +55,7 @@ function pollPlaylistReady() {
     timestamps = Array.from(timestamps);
 
     // Determine number of videos in playlist that are unplayable
-    let unplayableLength = parent.querySelectorAll("span[title='[Private video]']").length + parent.querySelectorAll("span[title='[Deleted video]']").length;
+    let unplayableLength = parent.querySelectorAll("a[title='[Private video]']").length + parent.querySelectorAll("a[title='[Deleted video]']").length;
 
     let playableLength = (unplayableLength > 0)
      ? videos.length - unplayableLength

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Youtube Playlist Duration Calculator",
   "short_name": "YTPD Calculator",
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icons": {
     "128": "icon128.png",
     "48": "icon48.png",


### PR DESCRIPTION
The unplayableLength-variable is not set correctly (anymore?), because the elements are not span-tags, but a-tags. Therefore it is always 0, leads to the condition in line 64 never evaluating to true and pollPlaylistReady gets executed indefinitely. Here an example with 5 privated/deleted videos in the first 105 elements:
![Screenshot from 2021-04-05 13-11-54](https://user-images.githubusercontent.com/6298910/113568451-df9a3300-9610-11eb-9721-7de1fa398552.png)
If you change the tag-type from span to a the privated/deleted videos are recognised again.
![Screenshot from 2021-04-05 12-36-52](https://user-images.githubusercontent.com/6298910/113568526-035d7900-9611-11eb-9236-0a463078f6d0.png)
