### PR TITLE
fix: bug with parsing total videos count

### DIFF
--- a/library.js
+++ b/library.js
@@ -222,7 +222,9 @@ const countTotalVideosInPlaylist = () => {
 
   if (!totalVideosStat) return null;
 
-  const totalVideoCount = parseInt(totalVideosStat.firstChild.innerText);
+  const totalVideoCount = parseInt(
+    totalVideosStat.firstChild.innerText.replace(/,/g, "")
+  );
 
   return totalVideoCount;
 };

--- a/ytpdc-firefox/library.js
+++ b/ytpdc-firefox/library.js
@@ -222,7 +222,9 @@ const countTotalVideosInPlaylist = () => {
 
   if (!totalVideosStat) return null;
 
-  const totalVideoCount = parseInt(totalVideosStat.firstChild.innerText);
+  const totalVideoCount = parseInt(
+    totalVideosStat.firstChild.innerText.replace(/,/g, "")
+  );
 
   return totalVideoCount;
 };


### PR DESCRIPTION
## What's changed
- Updated `countTotalVideosInPlaylist` in `library.js`

## Why
- This function assumed that the video count would be a flat number with no commas `e.g. 1100 instead of 1,100`, but that was not the case, which resulted in the `videos not counted` stat displaying negative numbers.