### PR TITLE
fix: checking if parsedInt is NaN before adding it to seconds

### DIFF
--- a/library.js
+++ b/library.js
@@ -99,7 +99,10 @@ const unformatTimestamp = (formattedTimestamp) => {
   let minutes = 1;
 
   while (components.length > 0) {
-    seconds += minutes * parseInt(components.pop(), 10);
+    let parsedInt = parseInt(components.pop(), 10);
+    if (isNaN(parsedInt)) continue;
+
+    seconds += minutes * parsedInt;
     minutes *= 60;
   }
 

--- a/ytpdc-firefox/library.js
+++ b/ytpdc-firefox/library.js
@@ -99,7 +99,10 @@ const unformatTimestamp = (formattedTimestamp) => {
   let minutes = 1;
 
   while (components.length > 0) {
-    seconds += minutes * parseInt(components.pop(), 10);
+    let parsedInt = parseInt(components.pop(), 10);
+    if (isNaN(parsedInt)) continue;
+
+    seconds += minutes * parsedInt;
     minutes *= 60;
   }
 


### PR DESCRIPTION
This is fixing the bug where it was showing NaN:NaN:NaN when there was a video without a visible timestamp (e.g. a premiere)

This pull request would close #17 

Tested with Firefox (web-ext). I made the same change to the chrome version, but I wasn't able to test it.