### PR TITLE
fix: ensure all timestamps available before start

### DIFF
--- a/library.js
+++ b/library.js
@@ -28,7 +28,8 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)) {
+    if (document.querySelector(config.timestampContainer)
+      && !getTimestamps(getVideos()).includes(null)) {
       clearInterval(playlistPoll);
       start();
     }

--- a/ytpdc-firefox/library.js
+++ b/ytpdc-firefox/library.js
@@ -28,7 +28,8 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)) {
+    if (document.querySelector(config.timestampContainer)
+      && !getTimestamps(getVideos()).includes(null)) {
       clearInterval(playlistPoll);
       start();
     }


### PR DESCRIPTION
There have been cases where the extension will start calculating the playlist duration before all the timestamps are available on the page and end up with different total durations on each page refresh. The current check only looks for the first timestamp to be available; this PR makes sure they all are available before calculating the duration.