### PR TITLE
fix: ensure all timestamps are available before processing

### DIFF
--- a/library.js
+++ b/library.js
@@ -28,7 +28,8 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)) {
+    if (document.querySelector(config.timestampContainer)
+      && !getTimestamps(getVideos()).includes(null)) {
       clearInterval(playlistPoll);
       start();
     }

--- a/library.js
+++ b/library.js
@@ -28,8 +28,10 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)
-      && !getTimestamps(getVideos()).includes(null)) {
+    if (
+      document.querySelector(config.timestampContainer) &&
+      countUnavailableTimestamps() === countUnavailableVideos()
+    ) {
       clearInterval(playlistPoll);
       start();
     }
@@ -90,7 +92,12 @@ const setupEventListeners = () => {
 };
 
 const getVideos = () => {
-  const videos = document.getElementsByTagName(config.videoElement);
+  const videoElementsContainer = document.querySelector(
+    config.videoElementsContainer
+  );
+  const videos = videoElementsContainer.getElementsByTagName(
+    config.videoElement
+  );
   return [...videos];
 };
 
@@ -204,8 +211,7 @@ const createPlaylistSummary = ({ timestamps, playlistDuration }) => {
   const totalVideosInPlaylist = countTotalVideosInPlaylist();
   const videosNotCounted = createSummaryItem(
     "Videos not counted:",
-    `${
-      totalVideosInPlaylist ? totalVideosInPlaylist - timestamps.length : "N/A"
+    `${totalVideosInPlaylist ? totalVideosInPlaylist - timestamps.length : "N/A"
     }`,
     "#fca5a5"
   );
@@ -272,6 +278,34 @@ const countTotalVideosInPlaylist = () => {
   );
 
   return totalVideoCount;
+};
+
+const countUnavailableVideos = () => {
+  const unavailableVideoTitles = [
+    "[Private video]",
+    "[Deleted video]",
+    "[Unavailable]",
+    "[Video unavailable]",
+    "[Restricted video]",
+    "[Age restricted]",
+  ];
+
+  const videoTitles = document.querySelectorAll("a#video-title");
+
+  let unavailableVideosCount = 0;
+
+  videoTitles.forEach((videoTitle) => {
+    if (unavailableVideoTitles.includes(videoTitle.title)) {
+      unavailableVideosCount++;
+    }
+  });
+
+  return unavailableVideosCount;
+};
+
+const countUnavailableTimestamps = () => {
+  const timestamps = getTimestamps(getVideos());
+  return timestamps.filter((timestamp) => timestamp === null).length;
 };
 
 const isDarkMode = () => {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Youtube Playlist Duration Calculator",
   "short_name": "YTPD Calculator",
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "icons": {
     "128": "icon128.png",
     "48": "icon48.png",

--- a/ytpdc-firefox/library.js
+++ b/ytpdc-firefox/library.js
@@ -28,7 +28,8 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)) {
+    if (document.querySelector(config.timestampContainer)
+      && !getTimestamps(getVideos()).includes(null)) {
       clearInterval(playlistPoll);
       start();
     }

--- a/ytpdc-firefox/library.js
+++ b/ytpdc-firefox/library.js
@@ -28,8 +28,10 @@ const pollPlaylistReady = () => {
   let playlistPoll = setInterval(() => {
     if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
-    if (document.querySelector(config.timestampContainer)
-      && !getTimestamps(getVideos()).includes(null)) {
+    if (
+      document.querySelector(config.timestampContainer) &&
+      countUnavailableTimestamps() === countUnavailableVideos()
+    ) {
       clearInterval(playlistPoll);
       start();
     }
@@ -90,7 +92,12 @@ const setupEventListeners = () => {
 };
 
 const getVideos = () => {
-  const videos = document.getElementsByTagName(config.videoElement);
+  const videoElementsContainer = document.querySelector(
+    config.videoElementsContainer
+  );
+  const videos = videoElementsContainer.getElementsByTagName(
+    config.videoElement
+  );
   return [...videos];
 };
 
@@ -204,8 +211,7 @@ const createPlaylistSummary = ({ timestamps, playlistDuration }) => {
   const totalVideosInPlaylist = countTotalVideosInPlaylist();
   const videosNotCounted = createSummaryItem(
     "Videos not counted:",
-    `${
-      totalVideosInPlaylist ? totalVideosInPlaylist - timestamps.length : "N/A"
+    `${totalVideosInPlaylist ? totalVideosInPlaylist - timestamps.length : "N/A"
     }`,
     "#fca5a5"
   );
@@ -272,6 +278,34 @@ const countTotalVideosInPlaylist = () => {
   );
 
   return totalVideoCount;
+};
+
+const countUnavailableVideos = () => {
+  const unavailableVideoTitles = [
+    "[Private video]",
+    "[Deleted video]",
+    "[Unavailable]",
+    "[Video unavailable]",
+    "[Restricted video]",
+    "[Age restricted]",
+  ];
+
+  const videoTitles = document.querySelectorAll("a#video-title");
+
+  let unavailableVideosCount = 0;
+
+  videoTitles.forEach((videoTitle) => {
+    if (unavailableVideoTitles.includes(videoTitle.title)) {
+      unavailableVideosCount++;
+    }
+  });
+
+  return unavailableVideosCount;
+};
+
+const countUnavailableTimestamps = () => {
+  const timestamps = getTimestamps(getVideos());
+  return timestamps.filter((timestamp) => timestamp === null).length;
 };
 
 const isDarkMode = () => {

--- a/ytpdc-firefox/manifest.json
+++ b/ytpdc-firefox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Youtube Playlist Duration Calculator",
   "short_name": "YTPD Calculator",
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "icons": {
     "128": "icon128.png",
     "48": "icon48.png",


### PR DESCRIPTION
## What's changed
- Updated logic that checks whether a playlist is ready to be processed
- Added functions to library
  - Count number of unavailable videos
  - Count number of unavailable timestamps
- Limit videos being counted to only the ones in the playlist

## Why
- The processing of timestamps could sometimes start before all the timestamps on the page are ready. This would lead to inaccurate calculations for the playlist duration.
- YouTube have also started to display recommended videos on the playlist overview page, this can affect the duration calculated and sometimes display negative values

## How
- Unavailable videos have a series of pre-defined titles e.g. [Private video], [Deleted video]
- By counting the number of videos that have such titles, and then counting the number of unavailable timestamps, we can use this information to determine whether all timestamps that can be loaded, have been loaded.