### PR TITLE
fix: logic which sums all timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/src/library.js
+++ b/src/library.js
@@ -93,7 +93,10 @@ const processPlaylist = () => {
   setupEventListeners();
   const videos = getVideos();
   const timestamps = getTimestampsFromVideos(videos);
-  const totalDurationInSeconds = timestamps.reduce((a, b) => a + b);
+  const totalDurationInSeconds =
+    Array.isArray(timestamps) && timestamps.length > 0
+      ? timestamps.reduce((a, b) => a + b)
+      : 0;
   const playlistDuration = formatTimestamp(totalDurationInSeconds);
   const playlistSummary = createPlaylistSummary({
     timestamps,

--- a/src/library.js
+++ b/src/library.js
@@ -148,18 +148,20 @@ const getVideos = () => {
  * @returns {Array<number>} timestamps
  */
 const getTimestampsFromVideos = (videos) => {
-  return videos.map((video) => {
-    if (!video) return null;
+  return videos
+    .map((video) => {
+      if (!video) return null;
 
-    const timestampContainer = video.querySelector(config.timestampContainer);
-    if (!timestampContainer) return null;
+      const timestampContainer = video.querySelector(config.timestampContainer);
+      if (!timestampContainer) return null;
 
-    const timestamp = timestampContainer.innerText;
-    if (!timestamp) return null;
+      const timestamp = timestampContainer.innerText;
+      if (!timestamp) return null;
 
-    const timestampInSeconds = convertTimestampToSeconds(timestamp);
-    return timestampInSeconds;
-  });
+      const timestampInSeconds = convertTimestampToSeconds(timestamp);
+      return timestampInSeconds;
+    })
+    .filter(Boolean);
 };
 
 const formatTimestamp = (timestamp) => {

--- a/src/library.js
+++ b/src/library.js
@@ -60,7 +60,7 @@ const displayLoader = () => {
 };
 
 const countUnavailableTimestamps = () => {
-  const timestamps = getTimestamps(getVideos());
+  const timestamps = getTimestampsFromVideos(getVideos());
   return timestamps.filter((timestamp) => timestamp === null).length;
 };
 
@@ -92,7 +92,7 @@ const processPlaylist = () => {
   setupPlaylistObserver();
   setupEventListeners();
   const videos = getVideos();
-  const timestamps = getTimestamps(videos);
+  const timestamps = getTimestampsFromVideos(videos);
   const totalDurationInSeconds = timestamps.reduce((a, b) => a + b);
   const playlistDuration = formatTimestamp(totalDurationInSeconds);
   const playlistSummary = createPlaylistSummary({
@@ -142,18 +142,23 @@ const getVideos = () => {
   return [...videos];
 };
 
-const getTimestamps = (videos) => {
+/**
+ * Extracts a list of numerical timestamps from a list of video elements
+ * @param {Array<Element>} videos
+ * @returns {Array<number>} timestamps
+ */
+const getTimestampsFromVideos = (videos) => {
   return videos.map((video) => {
     if (!video) return null;
 
     const timestampContainer = video.querySelector(config.timestampContainer);
     if (!timestampContainer) return null;
 
-    const formattedTimestamp = timestampContainer.innerText;
-    if (!formattedTimestamp) return null;
+    const timestamp = timestampContainer.innerText;
+    if (!timestamp) return null;
 
-    const timestamp = unformatTimestamp(formattedTimestamp);
-    return timestamp;
+    const timestampInSeconds = convertTimestampToSeconds(timestamp);
+    return timestampInSeconds;
   });
 };
 
@@ -242,8 +247,14 @@ const createPlaylistSummary = ({ timestamps, playlistDuration }) => {
   return summaryContainer;
 };
 
-const unformatTimestamp = (formattedTimestamp) => {
-  let timeComponents = formattedTimestamp
+/**
+ * Converts a textual timestamp formatted as hh:mm:ss to its numerical value
+ * represented in seconds
+ * @param {string} timestamp
+ * @returns {number}
+ */
+const convertTimestampToSeconds = (timestamp) => {
+  let timeComponents = timestamp
     .split(":")
     .map((timeComponent) => parseInt(timeComponent, 10));
 

--- a/src/library.js
+++ b/src/library.js
@@ -97,7 +97,7 @@ const processPlaylist = () => {
     Array.isArray(timestamps) && timestamps.length > 0
       ? timestamps.reduce((a, b) => a + b)
       : 0;
-  const playlistDuration = formatTimestamp(totalDurationInSeconds);
+  const playlistDuration = convertSecondsToTimestamp(totalDurationInSeconds);
   const playlistSummary = createPlaylistSummary({
     timestamps,
     playlistDuration
@@ -165,13 +165,18 @@ const getTimestampsFromVideos = (videos) => {
   });
 };
 
-const formatTimestamp = (timestamp) => {
-  let totalSeconds = timestamp;
-  const hours = `${Math.floor(totalSeconds / 3600)}`.padStart(2, "0");
-  totalSeconds %= 3600;
-  const minutes = `${Math.floor(totalSeconds / 60)}`.padStart(2, "0");
-  const seconds = `${totalSeconds % 60}`.padStart(2, "0");
-  return `${hours}:${minutes}:${seconds}`;
+/**
+ * Converts a numerical amount of seconds to a textual timestamp formatted as
+ * hh:mm:ss
+ * @param {number} seconds
+ * @returns {string}
+ */
+const convertSecondsToTimestamp = (seconds) => {
+  const hours = `${Math.floor(seconds / 3600)}`.padStart(2, "0");
+  seconds %= 3600;
+  const minutes = `${Math.floor(seconds / 60)}`.padStart(2, "0");
+  const remainingSeconds = `${seconds % 60}`.padStart(2, "0");
+  return `${hours}:${minutes}:${remainingSeconds}`;
 };
 
 const createPlaylistSummary = ({ timestamps, playlistDuration }) => {

--- a/src/library.js
+++ b/src/library.js
@@ -143,25 +143,23 @@ const getVideos = () => {
 };
 
 /**
- * Extracts a list of numerical timestamps from a list of video elements
+ * Extracts a list of timestamps from a list of video elements
  * @param {Array<Element>} videos
- * @returns {Array<number>} timestamps
+ * @returns {Array<number|null>} timestamps
  */
 const getTimestampsFromVideos = (videos) => {
-  return videos
-    .map((video) => {
-      if (!video) return null;
+  return videos.map((video) => {
+    if (!video) return null;
 
-      const timestampContainer = video.querySelector(config.timestampContainer);
-      if (!timestampContainer) return null;
+    const timestampContainer = video.querySelector(config.timestampContainer);
+    if (!timestampContainer) return null;
 
-      const timestamp = timestampContainer.innerText;
-      if (!timestamp) return null;
+    const timestamp = timestampContainer.innerText;
+    if (!timestamp) return null;
 
-      const timestampInSeconds = convertTimestampToSeconds(timestamp);
-      return timestampInSeconds;
-    })
-    .filter(Boolean);
+    const timestampInSeconds = convertTimestampToSeconds(timestamp);
+    return timestampInSeconds;
+  });
 };
 
 const formatTimestamp = (timestamp) => {

--- a/src/library.js
+++ b/src/library.js
@@ -146,7 +146,7 @@ const getVideos = () => {
 };
 
 /**
- * Extracts a list of timestamps from a list of video elements
+ * Extracts a list of timestamps from a list of video container elements
  * @param {Array<Element>} videos
  * @returns {Array<number|null>} timestamps
  */


### PR DESCRIPTION
### What's changed
- Make `.reduce()` get called only if there is an array & its length is > 0

### Why
- Previously, it was assuming that timestamps would always be an array with elements and never considered the case of a playlist with 0 valid timestamps
- This fixes #19 