### PR TITLE
refactor: disable sort by upload date for private playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ The extension is available for download at:
 ## Features
 
 - Calculate & display the total duration of a YouTube playlist
-- Sort playlists containing upto 100 videos, by the following criteria:
+- Sort playlists with 100 videos or less, by the following criteria:
   - Duration
   - Channel Name
   - View Count
-  - Upload Date
   - Index
+  - Upload Date (only for public playlists)
 
-> **Note:** The sorting feature is only enabled for playlists containing 100 videos
-> or less. This is because for larger playlists (>100 videos), YouTube only
-> loads videos in batches of 100 at a time as you scroll down the page and this
-> currently produces inconsistent & inaccurate sorting results.
+> **Note:** The sorting feature is only enabled for playlists containing 100
+> videos or less. This is because for larger playlists (>100 videos), YouTube
+> only loads the next 100 videos after you scroll to the bottom of the page.
+> This can often produce inconsistent & inaccurate sorting results, so it has
+> been disabled for now.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.0-beta.5",
+  "version": "2.1.0-beta.6",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/src/library/sorting.js
+++ b/src/library/sorting.js
@@ -249,7 +249,9 @@ const generateSortTypes = () => ({
     strategy: SortByViewsStrategy
   },
   uploadDate: {
-    enabled: videoHasElement("yt-formatted-string#video-info"),
+    enabled:
+      videoHasElement("yt-formatted-string#video-info") &&
+      !pageHasNativeSortFeature(),
     label: {
       asc: "Upload Date (Newest)",
       desc: "Upload Date (Oldest)"
@@ -267,6 +269,13 @@ const generateSortTypes = () => ({
 const videoHasElement = (identifier) => {
   const videoElement = document.querySelector(config.videoElement);
   return videoElement && videoElement.querySelector(identifier);
+};
+
+const pageHasNativeSortFeature = () => {
+  const nativeSortElement = document.querySelector(
+    "#filter-menu yt-sort-filter-sub-menu-renderer"
+  );
+  return nativeSortElement !== null;
 };
 
 /**


### PR DESCRIPTION
### What's changed & why
- If the page contains a native sort dropdown, sorting by upload date will be disabled
  - At the moment only Private playlists have this feature
  - The reason for this change is that the extension's sort featue conflicts with YouTube's native sort feature, producing inaccurate sorting results
    - For example, if you use the extension's sort feature to sort by upload date (newest) and then use YouTube's native sort feature to do the same, it would display a playlist that's sorted by upload date (oldest).
    - Given that YouTube already provides the ability to sort by upload date & addition date for Private playlists, there's no need for the extension to do the same & so it has been limited to Public playlists only
    
### Audit
<img width="1728" alt="image" src="https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/b89f269a-7ae5-4cae-b24e-10b2937fe9df">

### Screenshots
- Private playlist 
  <img width="350" alt="image" src="https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/35b82ae0-b022-4f27-9a71-dc29cc16ee3f">

- Public playlist 
  <img width="1222" alt="image" src="https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/4521f846-0335-43ed-920a-b634c7b16ded">
