### PR TITLE
refactor: source of language locale code

### DIFF
--- a/src/modules/sorting/index.js
+++ b/src/modules/sorting/index.js
@@ -60,7 +60,7 @@ export class PlaylistSorter {
         enabled:
           videoHasElement(elementSelectors.videoInfo) &&
           SortByViewsStrategy.supportedLocales.includes(
-            chrome.i18n.getUILanguage()
+            document.documentElement.lang
           ),
         label: {
           asc: chrome.i18n.getMessage("sortType_views_label_asc"),
@@ -73,7 +73,7 @@ export class PlaylistSorter {
           videoHasElement(elementSelectors.videoInfo) &&
           !pageHasNativeSortFeature() &&
           SortByUploadDateStrategy.supportedLocales.includes(
-            chrome.i18n.getUILanguage()
+            document.documentElement.lang
           ),
         label: {
           asc: chrome.i18n.getMessage("sortType_uploadDate_label_asc"),

--- a/src/modules/sorting/sort-by-upload-date/index.js
+++ b/src/modules/sorting/sort-by-upload-date/index.js
@@ -2,8 +2,17 @@ import { elementSelectors } from "src/shared/data/element-selectors";
 import { EnUploadDateParser } from "./parsers/en";
 import { ZhCnUploadDateParser } from "./parsers/zh_CN";
 
+const PARSERS_BY_LOCALE = {
+  "en": EnUploadDateParser,
+  "en-GB": EnUploadDateParser,
+  "en-IN": EnUploadDateParser,
+  "en-US": EnUploadDateParser,
+  "zh-Hans-CN": ZhCnUploadDateParser
+};
+
 export class SortByUploadDateStrategy {
-  static supportedLocales = ["en", "en-AU", "en-GB", "en-US", "zh-CN"];
+  static supportedLocales = Object.keys(PARSERS_BY_LOCALE);
+
   /**
    * Sorts a list of videos by their upload date
    * @param {Array<Element>} videos
@@ -35,7 +44,7 @@ export class SortByUploadDateStrategy {
    */
   parseUploadDate(videoInfo) {
     const context = new UploadDateParserContext();
-    context.setParser(chrome.i18n.getUILanguage());
+    context.setParser(document.documentElement.lang);
     return context.parse(videoInfo);
   }
 }
@@ -47,19 +56,8 @@ export class UploadDateParserContext {
 
   /** @param {string} locale */
   setParser(locale) {
-    switch (locale) {
-      case "en":
-      case "en-AU":
-      case "en-GB":
-      case "en-US":
-        this.parser = new EnUploadDateParser();
-        break;
-      case "zh-CN":
-        this.parser = new ZhCnUploadDateParser();
-        break;
-      default:
-        throw new Error("Unsupported locale for parsing upload dates");
-    }
+    const Parser = PARSERS_BY_LOCALE[locale] ?? EnUploadDateParser;
+    this.parser = new Parser();
   }
 
   /**

--- a/src/modules/sorting/sort-by-views/index.js
+++ b/src/modules/sorting/sort-by-views/index.js
@@ -5,7 +5,6 @@ import { ZhCnViewsParser } from "./parsers/zh_CN";
 const PARSERS_BY_LOCALE = {
   "en": EnViewsParser,
   "en-GB": EnViewsParser,
-  "en-IN": EnViewsParser,
   "en-US": EnViewsParser,
   "zh-Hans-CN": ZhCnViewsParser
 };

--- a/src/modules/sorting/sort-by-views/index.js
+++ b/src/modules/sorting/sort-by-views/index.js
@@ -2,8 +2,16 @@ import { elementSelectors } from "src/shared/data/element-selectors";
 import { EnViewsParser } from "./parsers/en";
 import { ZhCnViewsParser } from "./parsers/zh_CN";
 
+const PARSERS_BY_LOCALE = {
+  "en": EnViewsParser,
+  "en-GB": EnViewsParser,
+  "en-IN": EnViewsParser,
+  "en-US": EnViewsParser,
+  "zh-Hans-CN": ZhCnViewsParser
+};
+
 export class SortByViewsStrategy {
-  static supportedLocales = ["en", "en-AU", "en-GB", "en-US", "zh-CN"];
+  static supportedLocales = Object.keys(PARSERS_BY_LOCALE);
 
   /**
    * Sorts a list of videos by their view count
@@ -36,7 +44,7 @@ export class SortByViewsStrategy {
    */
   extractViews(videoInfo) {
     const context = new ViewsParserContext();
-    context.setParser(chrome.i18n.getUILanguage());
+    context.setParser(document.documentElement.lang);
     return context.parse(videoInfo);
   }
 }
@@ -48,19 +56,8 @@ export class ViewsParserContext {
 
   /** @param {string} locale */
   setParser(locale) {
-    switch (locale) {
-      case "en":
-      case "en-AU":
-      case "en-GB":
-      case "en-US":
-        this.parser = new EnViewsParser();
-        break;
-      case "zh-CN":
-        this.parser = new ZhCnViewsParser();
-        break;
-      default:
-        throw new Error("Unsupported locale for parsing views");
-    }
+    const Parser = PARSERS_BY_LOCALE[locale] ?? EnViewsParser;
+    this.parser = new Parser();
   }
 
   /** @param {Element} videoInfo */


### PR DESCRIPTION
## What's changed & why
- Refactored modules to use `document.documentElement.lang` as the source of the locale code instead of `chrome.i18n.getUILanguage`
  - It is more reliable to use the language set on YouTube rather than the browser/pc language, since users may be using a different language for each (pc, browser, youtube) 
- Updated `setParser` for sort by views & upload date to use (an object mapping locale codes to parsers) instead of (switch/case statements)
  - This is makes things easier to extend since now there is no longer a need to update the `supportedLocales` property separately each time a new locale/parser is added.

## Audit
![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/0ad2b242-ec04-4d36-b372-4f79fb4d4161)
