### PR TITLE
feat: implement spanish views parsers

### DIFF
--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -80,11 +80,11 @@
     "description": "Text to display for the descending 'sort by channel name' option"
   },
   "sortType_views_label_asc": {
-    "message": "Visualizaciones (Ascendente)",
+    "message": "Vistas (Ascendente)",
     "description": "Text to display for the ascending 'sort by views' option"
   },
   "sortType_views_label_desc": {
-    "message": "Visualizaciones (Descendente)",
+    "message": "Vistas (Descendente)",
     "description": "Text to display for the descending 'sort by views' option"
   },
   "sortType_uploadDate_label_asc": {

--- a/src/modules/sorting/sort-by-upload-date/index.js
+++ b/src/modules/sorting/sort-by-upload-date/index.js
@@ -1,17 +1,8 @@
 import { elementSelectors } from "src/shared/data/element-selectors";
-import { EnUploadDateParser } from "./parsers/en";
-import { ZhCnUploadDateParser } from "./parsers/zh_CN";
-
-const PARSERS_BY_LOCALE = {
-  "en": EnUploadDateParser,
-  "en-GB": EnUploadDateParser,
-  "en-IN": EnUploadDateParser,
-  "en-US": EnUploadDateParser,
-  "zh-Hans-CN": ZhCnUploadDateParser
-};
+import { getSupportedLocales, getUploadDateParser } from "./parsers";
 
 export class SortByUploadDateStrategy {
-  static supportedLocales = Object.keys(PARSERS_BY_LOCALE);
+  static supportedLocales = getSupportedLocales();
 
   /**
    * Sorts a list of videos by their upload date
@@ -56,7 +47,7 @@ export class UploadDateParserContext {
 
   /** @param {string} locale */
   setParser(locale) {
-    const Parser = PARSERS_BY_LOCALE[locale] ?? EnUploadDateParser;
+    const Parser = getUploadDateParser(locale);
     this.parser = new Parser();
   }
 

--- a/src/modules/sorting/sort-by-upload-date/parsers/index.js
+++ b/src/modules/sorting/sort-by-upload-date/parsers/index.js
@@ -1,0 +1,17 @@
+import { EnUploadDateParser } from "./en";
+import { ZhHansCnUploadDateParser } from "./zh-Hans-CN";
+
+const UPLOAD_DATE_PARSERS_BY_LOCALE = {
+  "en": EnUploadDateParser,
+  "en-GB": EnUploadDateParser,
+  "en-US": EnUploadDateParser,
+  "zh-Hans-CN": ZhHansCnUploadDateParser
+};
+
+/** @param {string} locale */
+export const getUploadDateParser = (locale) => {
+  return UPLOAD_DATE_PARSERS_BY_LOCALE[locale] ?? EnUploadDateParser;
+};
+
+export const getSupportedLocales = () =>
+  Object.keys(UPLOAD_DATE_PARSERS_BY_LOCALE);

--- a/src/modules/sorting/sort-by-upload-date/parsers/zh-Hans-CN.js
+++ b/src/modules/sorting/sort-by-upload-date/parsers/zh-Hans-CN.js
@@ -1,4 +1,4 @@
-export class ZhCnUploadDateParser {
+export class ZhHansCnUploadDateParser {
   /** @param {Element} videoInfo */
   parse(videoInfo) {
     const secondsByUnit = {

--- a/src/modules/sorting/sort-by-views/index.js
+++ b/src/modules/sorting/sort-by-views/index.js
@@ -1,16 +1,8 @@
 import { elementSelectors } from "src/shared/data/element-selectors";
-import { EnViewsParser } from "./parsers/en";
-import { ZhCnViewsParser } from "./parsers/zh_CN";
-
-const PARSERS_BY_LOCALE = {
-  "en": EnViewsParser,
-  "en-GB": EnViewsParser,
-  "en-US": EnViewsParser,
-  "zh-Hans-CN": ZhCnViewsParser
-};
+import { getSupportedLocales, getViewsParser } from "./parsers";
 
 export class SortByViewsStrategy {
-  static supportedLocales = Object.keys(PARSERS_BY_LOCALE);
+  static supportedLocales = getSupportedLocales();
 
   /**
    * Sorts a list of videos by their view count
@@ -55,7 +47,7 @@ export class ViewsParserContext {
 
   /** @param {string} locale */
   setParser(locale) {
-    const Parser = PARSERS_BY_LOCALE[locale] ?? EnViewsParser;
+    const Parser = getViewsParser(locale);
     this.parser = new Parser();
   }
 

--- a/src/modules/sorting/sort-by-views/parsers/es-ES.js
+++ b/src/modules/sorting/sort-by-views/parsers/es-ES.js
@@ -1,0 +1,25 @@
+export class EsViewsParser {
+  /** @param {Element} videoInfo */
+  parse(videoInfo) {
+    const viewsElement = videoInfo.firstElementChild;
+    const [value, unit] = viewsElement.textContent
+      .trim()
+      .toLowerCase()
+      .replaceAll(/\s/g, " ")
+      .split(" ");
+
+    const baseViews = parseFloat(value.replace(",", "."));
+
+    if (isNaN(baseViews)) {
+      return 0;
+    }
+
+    if (unit === "k") {
+      return Math.round(baseViews * 1000);
+    } else if (unit === "m") {
+      return Math.round(baseViews * 1_000_000);
+    } else {
+      return Math.round(baseViews);
+    }
+  }
+}

--- a/src/modules/sorting/sort-by-views/parsers/index.js
+++ b/src/modules/sorting/sort-by-views/parsers/index.js
@@ -1,0 +1,20 @@
+import { EnViewsParser } from "./en";
+import { EsViewsParser } from "./es-ES";
+import { ZhHansCnViewsParser } from "./zh-Hans-CN";
+
+const VIEWS_PARSERS_BY_LOCALE = {
+  "en": EnViewsParser,
+  "en-GB": EnViewsParser,
+  "en-US": EnViewsParser,
+  "es-ES": EsViewsParser,
+  "es-419": EsViewsParser,
+  "es-US": EsViewsParser,
+  "zh-Hans-CN": ZhHansCnViewsParser
+};
+
+/** @param {string} locale */
+export const getViewsParser = (locale) => {
+  return VIEWS_PARSERS_BY_LOCALE[locale] ?? EnViewsParser;
+};
+
+export const getSupportedLocales = () => Object.keys(VIEWS_PARSERS_BY_LOCALE);

--- a/src/modules/sorting/sort-by-views/parsers/zh-Hans-CN.js
+++ b/src/modules/sorting/sort-by-views/parsers/zh-Hans-CN.js
@@ -1,4 +1,4 @@
-export class ZhCnViewsParser {
+export class ZhHansCnViewsParser {
   /** @param {Element} videoInfo */
   parse(videoInfo) {
     const viewsElement = videoInfo.firstElementChild;


### PR DESCRIPTION
## What's changed
- Implemented spanish views parsers (es-ES, es-419, es-US)
- Moved `PARSERS_BY_LOCALE` into `parsers/index.js`
  - The parsers were being imported into `<sort-strategy>/index.js` only to be stored within `PARSERS_BY_LOCALE`
  - Moving both into a separate module cleans up the code in `<sort-strategy>/index.js`

## Why
- Parsing spanish views strings requires a few additional transformations of the text content