### PR TITLE
refactor: ui of sort dropdown

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -56,16 +56,77 @@
 }
 
 #ytpdc-sort-control {
+  width: 100%;
+  margin: 8px 0;
   display: flex;
   flex-direction: row;
-  margin: 8px 0;
   align-items: center;
-}
-
-#ytpdc-sort-control-options .hidden {
-  display: none;
 }
 
 #ytpdc-sort-control .label {
   padding-right: 8px;
+  flex-shrink: 0;
+}
+
+#ytpdc-sort-control-dropdown-container {
+  flex-grow: 1;
+  position: relative;
+}
+
+#ytpdc-sort-control-dropdown-button {
+  width: 100%;
+  padding: 8px;
+  margin: 0px;
+  border-radius: 4px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  column-gap: 16px;
+
+  appearance: button;
+  border: 1px solid transparent;
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-transform: none;
+  cursor: pointer;
+}
+
+#ytpdc-sort-control-dropdown-button span {
+  pointer-events: none;
+  text-align: start;
+}
+
+#ytpdc-sort-control-dropdown-button svg {
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+}
+
+#ytpdc-sort-control-dropdown-options {
+  width: 100%;
+  margin-top: 4px;
+  position: absolute;
+  z-index: 999;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(36px);
+}
+
+#ytpdc-sort-control-dropdown-options .hidden {
+  display: none;
+}
+
+.ytpdc-sort-control-dropdown-option {
+  padding: 4px 8px 4px 8px;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.ytpdc-sort-control-dropdown-option:hover {
+  background-color: rgba(255, 255, 255, 0.4);
 }

--- a/src/main.css
+++ b/src/main.css
@@ -55,38 +55,17 @@
   padding-left: 8px;
 }
 
-#ytpdc-sort-control.container {
+#ytpdc-sort-control {
   display: flex;
   flex-direction: row;
   margin: 8px 0;
   align-items: center;
 }
 
+#ytpdc-sort-control-options .hidden {
+  display: none;
+}
+
 #ytpdc-sort-control .label {
   padding-right: 8px;
-}
-
-#ytpdc-sort-control .group {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  column-gap: 4px;
-  padding: 4px;
-  border-radius: 4px;
-  background-color: rgba(0,0,0, 0.2);
-}
-
-#ytpdc-sort-control select {
-  width: 100%;
-  height: auto;
-  white-space: pre-wrap;
-  appearance: none;
-  color: #ddd;
-  background-color: transparent;
-  border-color: transparent;
-  outline-color: transparent;
-  outline-style: none;
-  cursor: pointer;
-  font-size: 1.5rem;
-  font-weight: 700;
 }

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -450,12 +450,15 @@ const createSortDropdown = (playlistObserver) => {
   labelElement.textContent = chrome.i18n.getMessage("sortDropdown_label");
 
   const dropdownElement = document.createElement("div");
+  dropdownElement.id = "ytpdc-sort-control-dropdown-container";
 
   const dropdownButtonElement = document.createElement("button");
-  dropdownButtonElement.id = "ytpdc-sort-control-button";
+  dropdownButtonElement.id = "ytpdc-sort-control-dropdown-button";
+
+  const dropdownButtonTextElement = document.createElement("span");
 
   const dropdownOptionsElement = document.createElement("div");
-  dropdownOptionsElement.id = "ytpdc-sort-control-options";
+  dropdownOptionsElement.id = "ytpdc-sort-control-dropdown-options";
   dropdownOptionsElement.classList.add("hidden");
 
   dropdownButtonElement.addEventListener("click", () => {
@@ -468,15 +471,19 @@ const createSortDropdown = (playlistObserver) => {
     dropdownOptionsElement.appendChild(sortOption);
   });
 
-  dropdownButtonElement.textContent = sortOptions[0].textContent;
+  dropdownButtonTextElement.textContent = sortOptions[0].textContent;
 
   dropdownOptionsElement.addEventListener("click", (event) => {
-    if (!event.target.classList.contains("ytpdc-sort-control-option")) return;
+    if (
+      !event.target.classList.contains("ytpdc-sort-control-dropdown-option")
+    ) {
+      return;
+    }
 
     window.ytpdc.sortDropdown.used = true;
 
     dropdownOptionsElement.classList.toggle("hidden");
-    dropdownButtonElement.textContent = event.target.textContent;
+    dropdownButtonTextElement.textContent = event.target.textContent;
 
     playlistObserver?.disconnect();
 
@@ -497,13 +504,13 @@ const createSortDropdown = (playlistObserver) => {
     "http://www.w3.org/2000/svg",
     "svg"
   );
-  caretDownIcon.style.width = "1em";
-  caretDownIcon.style.height = "1em";
   caretDownIcon.setAttribute("viewBox", "0 0 256 256");
   caretDownIcon.innerHTML = `<path fill="currentColor" d="m216.49 104.49l-80
   80a12 12 0 0 1-17 0l-80-80a12 12 0 0 1 17-17L128 159l71.51-71.52a12 12 0 0 1
   17 17Z"/>`;
 
+  dropdownButtonElement.appendChild(dropdownButtonTextElement);
+  dropdownButtonElement.appendChild(caretDownIcon);
   dropdownElement.appendChild(dropdownButtonElement);
   dropdownElement.appendChild(dropdownOptionsElement);
   containerElement.appendChild(labelElement);

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -442,32 +442,50 @@ const countTotalVideosInPlaylist = () => {
 };
 
 const createSortDropdown = (playlistObserver) => {
-  const container = document.createElement("div");
-  container.id = "ytpdc-sort-control";
-  container.classList.add("container");
+  const containerElement = document.createElement("div");
+  containerElement.id = "ytpdc-sort-control";
 
-  const label = document.createElement("p");
-  label.classList.add("label");
-  label.textContent = chrome.i18n.getMessage("sortDropdown_label");
+  const labelElement = document.createElement("p");
+  labelElement.classList.add("label");
+  labelElement.textContent = chrome.i18n.getMessage("sortDropdown_label");
 
-  const group = document.createElement("div");
-  group.classList.add("group");
+  const dropdownElement = document.createElement("div");
 
-  const dropdown = document.createElement("select");
+  const dropdownButtonElement = document.createElement("button");
+  dropdownButtonElement.id = "ytpdc-sort-control-button";
 
-  PlaylistSorter.getSortOptions().forEach((sortOption) => {
-    dropdown.appendChild(sortOption);
+  const dropdownOptionsElement = document.createElement("div");
+  dropdownOptionsElement.id = "ytpdc-sort-control-options";
+  dropdownOptionsElement.classList.add("hidden");
+
+  dropdownButtonElement.addEventListener("click", () => {
+    dropdownOptionsElement.classList.toggle("hidden");
   });
 
-  dropdown.addEventListener("change", (event) => {
+  const sortOptions = PlaylistSorter.getSortOptions();
+
+  sortOptions.forEach((sortOption) => {
+    dropdownOptionsElement.appendChild(sortOption);
+  });
+
+  dropdownButtonElement.textContent = sortOptions[0].textContent;
+
+  dropdownOptionsElement.addEventListener("click", (event) => {
+    if (!event.target.classList.contains("ytpdc-sort-control-option")) return;
+
     window.ytpdc.sortDropdown.used = true;
+
+    dropdownOptionsElement.classList.toggle("hidden");
+    dropdownButtonElement.textContent = event.target.textContent;
 
     playlistObserver?.disconnect();
 
     const playlistElement = document.querySelector(elementSelectors.playlist);
     const videos = playlistElement.getElementsByTagName(elementSelectors.video);
 
-    const playlistSorter = new PlaylistSorter(event.target.value);
+    const playlistSorter = new PlaylistSorter(
+      event.target.getAttribute("value")
+    );
     const sortedVideos = playlistSorter.sort([...videos].slice(0, 100));
 
     playlistElement.replaceChildren(...sortedVideos);
@@ -486,12 +504,12 @@ const createSortDropdown = (playlistObserver) => {
   80a12 12 0 0 1-17 0l-80-80a12 12 0 0 1 17-17L128 159l71.51-71.52a12 12 0 0 1
   17 17Z"/>`;
 
-  container.appendChild(label);
-  group.appendChild(dropdown);
-  group.appendChild(caretDownIcon);
-  container.appendChild(group);
+  dropdownElement.appendChild(dropdownButtonElement);
+  dropdownElement.appendChild(dropdownOptionsElement);
+  containerElement.appendChild(labelElement);
+  containerElement.appendChild(dropdownElement);
 
-  return container;
+  return containerElement;
 };
 
 export { main };

--- a/src/modules/sorting/index.js
+++ b/src/modules/sorting/index.js
@@ -85,7 +85,7 @@ export class PlaylistSorter {
   }
 
   /**
-   * Generates a list of <option> elements for each type of sort
+   * Generates a list of <div> elements representing each type of sort
    */
   static getSortOptions() {
     const sortTypes = PlaylistSorter.getSortTypes();
@@ -93,10 +93,11 @@ export class PlaylistSorter {
       const { enabled, label } = sortTypes[sortType];
       if (!enabled) return [];
       return Object.keys(label).map((sortOrder) => {
-        const option = document.createElement("option");
-        option.value = `${sortType}:${sortOrder}`;
-        option.textContent = label[sortOrder];
-        return option;
+        const optionElement = document.createElement("div");
+        optionElement.classList.add("ytpdc-sort-control-option");
+        optionElement.setAttribute("value", `${sortType}:${sortOrder}`);
+        optionElement.textContent = label[sortOrder];
+        return optionElement;
       });
     });
   }

--- a/src/modules/sorting/index.js
+++ b/src/modules/sorting/index.js
@@ -94,7 +94,7 @@ export class PlaylistSorter {
       if (!enabled) return [];
       return Object.keys(label).map((sortOrder) => {
         const optionElement = document.createElement("div");
-        optionElement.classList.add("ytpdc-sort-control-option");
+        optionElement.classList.add("ytpdc-sort-control-dropdown-option");
         optionElement.setAttribute("value", `${sortType}:${sortOrder}`);
         optionElement.textContent = label[sortOrder];
         return optionElement;


### PR DESCRIPTION
## What's changed
- Refactored styles of sort dropdown and also updated the layout of the elements

## Why
- Browsers implement their own native styles for the `<select>` element.
- With the previous setup, the styles that were okay on Mac, were broken on Windows (contrast wise)
- Since there's no way to affect the native styling via CSS, it made sense to implement a custom dropdown, so that the styles can be consistent.

## Screenshots
- Windows
  - Chrome
    ![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/fe3e7a6f-9321-41ed-8adf-294a500e08f0)
  - Firefox 
    ![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/735f8cab-bdc9-4471-8a5c-fe1af565011d)
- MacOS
  - Chrome 
    <img width="1196" alt="image" src="https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/017357e1-673b-4303-86b8-07fca4db6eae">
  - Firefox
    <img width="1278" alt="image" src="https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/ba790c5c-96a6-417e-8715-c6e369dbd0fc">
