### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v2.1.1] - 2024-04-13
+
+### Fixed
+
+- Fixed an issue with timestamp strings not being parsed correctly leading to an
+  inaccurate total duration being calculated
+  - It appears something may have changed recently with how timestamps are
+    rendered since the timestamp DOM element now has a chance to contain
+    duplicate timstamp strings, e.g. `04:20\n 04:20`
+  - So when `convertTimestampToSeconds` gets such a timestamp and attempts to
+    split it by `:`, the end result is 4 time components: `[4, 20, 4, 20]`
+  - To fix this, `getTimestampFromVideo` will now use a regular expression to
+    extract the timestamp from the DOM element
+
+## [v2.1.0] - 2024-04-07
+
+### Added
+
+- Added ability to sort playlists by different criteria (index, duration, views, channel name, upload date)
+- Added i18n support & language translations:
+  - English (en, en-GB, en-IN, en-US)
+  - Spanish (es, es-419, es-us)
+  - Portuguese (pt-PT, pt-BR)
+  - Chinese (zh-Hans-CN, zh-Hant-TW)
+- Added & updated documentation (README, testing, adding translations)
+
+### Changed
+
+- Migrated package manager from npm to pnpm
+- Refactored several parts of codebase to reduce complexity
+
+### Fixed
+
+- Fixed several bugs
+  - Bug with mutation observer not disconnecting when navigating between playlists
+  - Bug where timestamps were not being summed properly
+- Addressed vulnerabilities reported by pnpm audit and dependabot

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/src/shared/modules/timestamp.js
+++ b/src/shared/modules/timestamp.js
@@ -56,7 +56,7 @@ export const getTimestampFromVideo = (video) => {
   // Ref: Timestamp regex from https://stackoverflow.com/a/8318367
   const timestampSanitized = timestamp
     .trim()
-    .replace("\n", "")
+    .replace(/\n/g, "")
     .match(/((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))/)[0];
 
   const timestampAsSeconds = convertTimestampToSeconds(timestampSanitized);

--- a/src/shared/modules/timestamp.js
+++ b/src/shared/modules/timestamp.js
@@ -53,6 +53,12 @@ export const getTimestampFromVideo = (video) => {
   const timestamp = timestampElement.innerText;
   if (!timestamp) return null;
 
-  const timestampAsSeconds = convertTimestampToSeconds(timestamp);
+  // Ref: Timestamp regex from https://stackoverflow.com/a/8318367
+  const timestampSanitized = timestamp
+    .trim()
+    .replace("\n", "")
+    .match(/((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))/)[0];
+
+  const timestampAsSeconds = convertTimestampToSeconds(timestampSanitized);
   return timestampAsSeconds;
 };


### PR DESCRIPTION
## What's changed & why

- Fixed an issue with timestamp strings not being parsed correctly leading to an
  inaccurate total duration being calculated
  - It appears something may have changed recently with how timestamps are
    rendered since the timestamp DOM element now has a chance to contain
    duplicate timstamp strings, e.g. `04:20\n 04:20`
  - So when `convertTimestampToSeconds` gets such a timestamp and attempts to
    split it by `:`, the end result is 4 time components: `[4, 20, 4, 20]`
  - To fix this, `getTimestampFromVideo` will now: 
    - Use a regular expression to extract the timestamp from the DOM element
    - Replace all occurences of `\n` in the timestamp string

## Screenshots

- Before
  - ![Screenshot 2024-04-13 101714](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/a0f0d014-3d54-4447-938f-ea9f474b2ae0)
- After
  - ![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/4c59195d-3d1c-4bf2-b995-f98f3c5c6c1a)
