### PR TITLE
Release v2.1.2

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,8 @@ This document describes the process involved in testing the extension.
 
 - For each type of playlist
   - [ ] Visit playlist page
+  - [ ] Verify extension loaded
+    - There should be a log in the browser console with the text `Loaded.`
   - [ ] Verify the following
     - [ ] A summary section is displayed within the playlist information panel
           located on the left-hand side of the page
@@ -60,3 +62,5 @@ This document describes the process involved in testing the extension.
             summary section
       - [ ] Selecting the "Show unavailable videos" settings triggers a
             recalulation of the playlist duration
+- For non-playlist pages, after 15 seconds have elapsed there should be a yellow
+  warning log in the browser console with the text `Could not find a playlist.`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,14 @@
 import { main } from "src/modules/index";
 import "./main.css";
+import { logger } from "./shared/modules/logger";
 
 // Entry-point
 if (document.readyState !== "loading") {
+  logger.info("Loaded.");
   main();
 } else {
   document.addEventListener("DOMContentLoaded", () => {
+    logger.info("Loaded.");
     main();
   });
 }

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -160,6 +160,12 @@ const setupPage = () => {
   };
 
   const onYoutubeNavigationFinished = () => {
+    document.removeEventListener(
+      "yt-navigate-finish",
+      onYoutubeNavigationFinished,
+      false
+    );
+
     window.ytpdc.playlistObserver?.disconnect();
 
     window.ytpdc = {

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -17,7 +17,7 @@ const checkPlaylistReady = () => {
   let pollCount = 0;
 
   let playlistPoll = setInterval(() => {
-    if (pollCount >= maxPollCount) return clearInterval(playlistPoll);
+    if (pollCount >= maxPollCount) clearInterval(playlistPoll);
 
     if (pollCount > 15 && window.location.pathname !== "/playlist") {
       logger.warn("Could not find a playlist.");

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -16,7 +16,7 @@ const checkPlaylistReady = () => {
   let pollCount = 0;
 
   let playlistPoll = setInterval(() => {
-    if (pollCount >= maxPollCount) clearInterval(playlistPoll);
+    if (pollCount >= maxPollCount) return clearInterval(playlistPoll);
 
     if (pollCount > 15 && window.location.pathname !== "/playlist") {
       clearInterval(playlistPoll);
@@ -24,6 +24,7 @@ const checkPlaylistReady = () => {
     }
 
     if (
+      document.querySelector(elementSelectors.playlist) &&
       document.querySelector(elementSelectors.timestamp) &&
       countUnavailableTimestamps() === countUnavailableVideos()
     ) {
@@ -72,8 +73,14 @@ const countUnavailableTimestamps = () => {
     .filter((timestamp) => timestamp === null).length;
 };
 
+/**
+ * Returns a list of video elements found within the playlist element
+ * @returns {Element[]}
+ **/
 const getVideos = () => {
   const playlistElement = document.querySelector(elementSelectors.playlist);
+  if (!playlistElement) return [];
+
   const videos = playlistElement.getElementsByTagName(elementSelectors.video);
   return [...videos];
 };

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -4,8 +4,10 @@ import {
   convertSecondsToTimestamp,
   getTimestampFromVideo
 } from "src/shared/modules/timestamp";
+import { logger } from "src/shared/modules/logger";
 
 const main = () => {
+  logger.info("Loaded.");
   checkPlaylistReady();
 };
 
@@ -19,6 +21,7 @@ const checkPlaylistReady = () => {
     if (pollCount >= maxPollCount) return clearInterval(playlistPoll);
 
     if (pollCount > 15 && window.location.pathname !== "/playlist") {
+      logger.warn("Could not find a playlist.");
       clearInterval(playlistPoll);
       return;
     }
@@ -128,6 +131,7 @@ const getVideoTitle = (video) => {
 };
 
 const processPlaylist = () => {
+  logger.info("Processing playlist...");
   setupPage();
   const playlistObserver = setupPlaylistObserver();
   const videos = getVideos();
@@ -142,6 +146,7 @@ const processPlaylist = () => {
     playlistDuration,
     playlistObserver
   });
+  logger.info("Finished processing playlist.");
 };
 
 const setupPage = () => {

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -7,7 +7,6 @@ import {
 import { logger } from "src/shared/modules/logger";
 
 const main = () => {
-  logger.info("Loaded.");
   checkPlaylistReady();
 };
 

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -130,7 +130,6 @@ const getVideoTitle = (video) => {
 };
 
 const processPlaylist = () => {
-  logger.info("Processing playlist...");
   setupPage();
   const playlistObserver = setupPlaylistObserver();
   const videos = getVideos();
@@ -145,7 +144,6 @@ const processPlaylist = () => {
     playlistDuration,
     playlistObserver
   });
-  logger.info("Finished processing playlist.");
 };
 
 const setupPage = () => {

--- a/src/shared/modules/logger.js
+++ b/src/shared/modules/logger.js
@@ -1,0 +1,23 @@
+class Logger {
+  static instance;
+
+  constructor() {
+    const { version } = chrome.runtime.getManifest();
+    this.prefix = `YTPDC (v${version}):`;
+  }
+
+  static getInstance() {
+    return Logger.instance ? Logger.instance : new Logger();
+  }
+
+  logWithPrefix(logMethod) {
+    return (...args) => logMethod(this.prefix, ...args);
+  }
+
+  info = this.logWithPrefix(console.info);
+  debug = this.logWithPrefix(console.debug);
+  warn = this.logWithPrefix(console.warn);
+  error = this.logWithPrefix(console.error);
+}
+
+export const logger = Logger.getInstance();

--- a/src/shared/modules/timestamp.js
+++ b/src/shared/modules/timestamp.js
@@ -53,9 +53,10 @@ export const getTimestampFromVideo = (video) => {
   const timestamp = timestampElement.innerText;
   if (!timestamp) return null;
 
-  // Ref: Timestamp regex from https://stackoverflow.com/a/8318367
   const sanitizedTimestamp = timestamp.trim().replace(/\n/g, "");
 
+  // Does the timetamp match hh:mm:ss?
+  // Ref: Timestamp regex from https://stackoverflow.com/a/8318367
   const matches = sanitizedTimestamp.match(
     /((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))/
   );

--- a/src/shared/modules/timestamp.js
+++ b/src/shared/modules/timestamp.js
@@ -54,12 +54,16 @@ export const getTimestampFromVideo = (video) => {
   if (!timestamp) return null;
 
   // Ref: Timestamp regex from https://stackoverflow.com/a/8318367
-  const timestampSanitized = timestamp
-    .trim()
-    .replace(/\n/g, "")
-    .toLowerCase()
-    .match(/((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))|upcoming/)[0];
+  const sanitizedTimestamp = timestamp.trim().replace(/\n/g, "");
 
-  const timestampAsSeconds = convertTimestampToSeconds(timestampSanitized);
-  return timestampAsSeconds;
+  const matches = sanitizedTimestamp.match(
+    /((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))/
+  );
+
+  if (matches) {
+    return convertTimestampToSeconds(matches[0]);
+  } else {
+    // Timestamp exists but does not match hh:mm:ss, treat it as 0 seconds
+    return 0;
+  }
 };

--- a/src/shared/modules/timestamp.js
+++ b/src/shared/modules/timestamp.js
@@ -57,7 +57,8 @@ export const getTimestampFromVideo = (video) => {
   const timestampSanitized = timestamp
     .trim()
     .replace(/\n/g, "")
-    .match(/((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))/)[0];
+    .toLowerCase()
+    .match(/((?:(?:([01]?\d|2[0-3]):)?([0-5]?\d):)?([0-5]?\d))|upcoming/)[0];
 
   const timestampAsSeconds = convertTimestampToSeconds(timestampSanitized);
   return timestampAsSeconds;


### PR DESCRIPTION
## What's changed
- Fixed bug with extension on non-playlist pages
  - On non-playlist pages, there was no playlist element detected but `getVideos()` was incorrectly assuming it to exist, so there was a spam of error logs in the browser console
  - It should now properly check if the playlist element exists before calling `countUnvailableVideos()` and `countUnavailableTimestamps()`
  - Alternatively, `getVideos()` now returns an empty array if no playlist element is found
- Fixed bug where playlists containing "Upcoming" videos would not calculate a total duration
- Fixed bug where the `yt-navigate-finish` event listener was not being removed before a new one could be added
  - This meant that when navigating between multiple playlists, there would be multiple listener callbacks being invoked unnecessarily 
- Add a new shared module `logger`
- Updated testing doc
- Add a few console logs
  - 1x info log to indicate extension was loaded
  - 1x warning log in `checkPlaylistReady` to indicate when no playlist could be found
  
## Screenshots
![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/94db7597-cab1-48d3-82a4-0fb3a1020262)
![image](https://github.com/nrednav/youtube-playlist-duration-calculator/assets/26251262/f9b441b1-2a1d-4e18-bc8a-80ba00d04398)
