### PR TITLE
Release v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.4] - 2024-07-26
+
+### Removed
+
+- Removed code which checks whether the video has a channel name from the
+  `isVideoUnavailable` function
+  - Found a rare situation where a
+    [video](https://www.youtube.com/watch?v=QwtyIDmhxh4) (as of 2024-07-26) had
+    a valid title and timestamp but no channel name
+  - This incorrectly flagged the video as "unavailable"
+  - The `checkPlaylistReady` function relies on the count of unavailable videos
+    & timestamps to determine whether a playlist is ready to be processed
+  - The video being incorrectly flagged, led to one count being higher than the
+    other, and so the extension determined the playlist was "not ready"
+
 ## [v2.1.3] - 2024-07-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,9 @@ const checkPlaylistReady = () => {
   let pollCount = 0;
 
   let playlistPoll = setInterval(() => {
-    if (pollCount >= maxPollCount) clearInterval(playlistPoll);
+    if (pollCount >= maxPollCount) {
+      clearInterval(playlistPoll);
+    }
 
     const playlistElement = document.querySelector(elementSelectors.playlist);
     const playlistExists = playlistElement !== null;
@@ -50,11 +52,13 @@ const checkPlaylistReady = () => {
 
     const timestampElement = document.querySelector(elementSelectors.timestamp);
     const timestampExists = timestampElement !== null;
+    const unavailableTimestampsCount = countUnavailableTimestamps();
+    const unavailableVideosCount = countUnavailableVideos();
 
     if (
       playlistExists &&
       timestampExists &&
-      countUnavailableTimestamps() === countUnavailableVideos()
+      unavailableTimestampsCount === unavailableVideosCount
     ) {
       clearInterval(playlistPoll);
 
@@ -208,6 +212,11 @@ const countUnavailableVideos = () => {
 /**
  * Checks whether a given video element meets the criteria for being considered
  * "unavailable"
+ *
+ * Criteria:
+ * - Has no timestamp
+ * - Title is unavailable
+ *
  * @param {Element} video
  */
 const isVideoUnavailable = (video) => {
@@ -226,11 +235,6 @@ const isVideoUnavailable = (video) => {
   ].includes(getVideoTitle(video));
 
   if (hasUnavailableTitle) return true;
-
-  const hasNoChannelName =
-    video.querySelector(elementSelectors.channelName)?.innerText.trim() === "";
-
-  if (hasNoChannelName) return true;
 
   return false;
 };


### PR DESCRIPTION
## What's changed

- Fixed a bug with the `isVideoUnavailable` function
  - Found this [video](https://www.youtube.com/watch?v=QwtyIDmhxh4) in a playlist
  - It had a valid title & timestamp but no channel name
  - This lead to `isVideoUnavailable` incorrectly reporting that the video was unavailable
  - This in turn led to `checkPlaylistReady` failing because `countUnavailableVideos` and `countUnavailableTimestamps` were no longer equal
  - Moving forward, it's not necessary to check the channel name since the checks against the timestamp & title are more than enough

## Results

### Audit
![image](https://github.com/user-attachments/assets/2cda9bff-d9f2-43b3-b9f3-995fd20f8981)
