### PR TITLE
Release v2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     depending on if the user has YouTube premium or not
   - This function will take that into account and use the appropriate selector
     to find the metadata element
-- Added `playlistDownloadButton` to list of element selectors
 - Added `youtubePremium` variant to list of `playlistMetadata` element selectors
 
 ## [v2.1.4] - 2024-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.5] - 2024-07-27
+
+### Added
+
 ## [v2.1.4] - 2024-07-26
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added try-catch error handling to `main()`
+- Created `getPlaylistMetadataElement` function
+  - The playlist metadata element appears to have a different identifier
+    depending on if the user has YouTube premium or not
+  - This function will take that into account and use the appropriate selector
+    to find the metadata element
+- Added `playlistDownloadButton` to list of element selectors
+- Added `youtubePremium` variant to list of `playlistMetadata` element selectors
+
 ## [v2.1.4] - 2024-07-26
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "vite",
     "build:chrome": "pnpm run clean && vite build --mode chrome",
     "build:firefox": "pnpm run clean && vite build --mode firefox",
+    "test": "node --test",
     "clean": "pnpm exec del dist/",
     "watch": "pnpm run clean && vite build --watch --mode development",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An extension to calculate & display the total duration of a youtube playlist.",
   "author": "nrednav",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "engines": {
     "node": ">=20",

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1,0 +1,98 @@
+{
+  "loaderMessage": {
+    "message": "Calcul en cours...",
+    "description": "Text to display when the extension is loading"
+  },
+  "videoTitle_private": {
+    "message": "[Vidéo privée]",
+    "description": "Title displayed by YouTube for private videos"
+  },
+  "videoTitle_deleted": {
+    "message": "[Vidéo supprimée]",
+    "description": "Title displayed by YouTube for deleted videos"
+  },
+  "videoTitle_unavailable_v1": {
+    "message": "[Indisponible]",
+    "description": "First variation of title displayed by YouTube for unavailable videos"
+  },
+  "videoTitle_unavailable_v2": {
+    "message": "[Vidéo indisponible]",
+    "description": "Second variation of title displayed by YouTube for unavailable videos"
+  },
+  "videoTitle_restricted": {
+    "message": "[Vidéo restreinte]",
+    "description": "Title displayed by YouTube for restricted videos"
+  },
+  "videoTitle_ageRestricted": {
+    "message": "[Limite d'âge]",
+    "description": "Title displayed by YouTube for age-restricted videos"
+  },
+  "problemEncountered_paragraphOne": {
+    "message": "Un problème est survenu.",
+    "description": "Text to display in first paragraph when a problem has been encountered"
+  },
+  "problemEncountered_paragraphTwo": {
+    "message": "Veuillez recharger cette page pour recalculer la durée de la playlist.",
+    "description": "Text to display in second paragraph when a problem has been encountered"
+  },
+  "playlistSummary_totalDuration": {
+    "message": "Durée totale:",
+    "description": "Text to display as label for the playlist duration"
+  },
+  "playlistSummary_videosCounted": {
+    "message": "Vidéos comptées:",
+    "description": "Text to display as label for the videos counted"
+  },
+  "playlistSummary_videosNotCounted": {
+    "message": "Vidéos non comptées:",
+    "description": "Text to display as label for the videos not counted"
+  },
+  "playlistSummary_tooltip": {
+    "message": "Faites défiler vers le bas pour compter plus de vidéos",
+    "description": "Text to display within tooltip"
+  },
+  "sortDropdown_label": {
+    "message": "Trier par:",
+    "description": "Text to display as label for the sort dropdown"
+  },
+  "sortType_index_label_asc": {
+    "message": "Index (Croissant)",
+    "description": "Text to display for the ascending 'sort by index' option"
+  },
+  "sortType_index_label_desc": {
+    "message": "Index (Décroissant)",
+    "description": "Text to display for the descending 'sort by index' option"
+  },
+  "sortType_duration_label_asc": {
+    "message": "Durée (Plus courte)",
+    "description": "Text to display for the ascending 'sort by duration' option"
+  },
+  "sortType_duration_label_desc": {
+    "message": "Durée (Plus longue)",
+    "description": "Text to display for the descending 'sort by duration' option"
+  },
+  "sortType_channelName_label_asc": {
+    "message": "Nom de chaîne (A-Z)",
+    "description": "Text to display for the ascending 'sort by channel name' option"
+  },
+  "sortType_channelName_label_desc": {
+    "message": "Nom de chaîne (Z-A)",
+    "description": "Text to display for the descending 'sort by channel name' option"
+  },
+  "sortType_views_label_asc": {
+    "message": "Vues (Moins vues)",
+    "description": "Text to display for the ascending 'sort by views' option"
+  },
+  "sortType_views_label_desc": {
+    "message": "Vues (Plus vues)",
+    "description": "Text to display for the descending 'sort by views' option"
+  },
+  "sortType_uploadDate_label_asc": {
+    "message": "Date de mise en ligne (Plus récente)",
+    "description": "Text to display for the ascending 'sort by upload date' option"
+  },
+  "sortType_uploadDate_label_desc": {
+    "message": "Date de mise en ligne (Plus ancienne)",
+    "description": "Text to display for the descending 'sort by upload date' option"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -532,19 +532,9 @@ const getPlaylistMetadataElement = () => {
   );
 
   if (!playlistMetadataElement) {
-    const playlistDownloadButton = document.querySelector(
-      elementSelectors.playlistDownloadButton
+    return document.querySelector(
+      elementSelectors.playlistMetadata.youtubePremium
     );
-
-    const userHasYoutubePremium = isElementVisible(playlistDownloadButton);
-
-    if (userHasYoutubePremium) {
-      return document.querySelector(
-        elementSelectors.playlistMetadata.youtubePremium
-      );
-    } else {
-      return null;
-    }
   }
 
   return playlistMetadataElement;

--- a/src/modules/sorting/sort-by-upload-date/parsers/fr.js
+++ b/src/modules/sorting/sort-by-upload-date/parsers/fr.js
@@ -1,0 +1,28 @@
+export class FrUploadDateParser {
+  /** @param {Element} videoInfo */
+  parse(videoInfo) {
+    const secondsByUnit = {
+      minute: 60,
+      heure: 60 * 60,
+      jour: 1 * 86400,
+      semaine: 7 * 86400,
+      mois: 30 * 86400,
+      an: 365 * 86400
+    };
+
+    const uploadDateRegex =
+      /(?:Diffusé )?il y a (\d+) (minutes?|heures?|jours?|semaines?|mois|ans?)/u;
+
+    const uploadDateElement = videoInfo.children[2];
+
+    const [value, unit] = uploadDateElement.textContent
+      .toLowerCase()
+      .match(uploadDateRegex)
+      .slice(1);
+
+    const seconds =
+      secondsByUnit[unit] ?? secondsByUnit[unit.slice(0, -1)] ?? 1;
+
+    return parseFloat(value) * seconds;
+  }
+}

--- a/src/modules/sorting/sort-by-upload-date/parsers/fr.test.js
+++ b/src/modules/sorting/sort-by-upload-date/parsers/fr.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert";
+import { FrUploadDateParser } from "./fr.js";
+
+test.describe("upload-date-parser/fr", () => {
+  const testCases = [
+    { input: "il y a 1 minute", expected: 1 * 60 },
+    { input: "il y a 2 minutes", expected: 2 * 60 },
+    { input: "il y a 1 heure", expected: 1 * 3600 },
+    { input: "il y a 2 heures", expected: 2 * 3600 },
+    { input: "il y a 1 jour", expected: 1 * 86400 },
+    { input: "il y a 2 jours", expected: 2 * 86400 },
+    { input: "il y a 1 semaine", expected: 1 * 7 * 86400 },
+    { input: "il y a 2 semaines", expected: 2 * 7 * 86400 },
+    { input: "il y a 1 mois", expected: 1 * 30 * 86400 },
+    { input: "il y a 2 mois", expected: 2 * 30 * 86400 },
+    { input: "il y a 1 an", expected: 1 * 365 * 86400 },
+    { input: "il y a 2 ans", expected: 2 * 365 * 86400 }
+  ];
+
+  const parser = new FrUploadDateParser();
+
+  for (const testCase of testCases) {
+    test(testCase.input, () => {
+      const variants = [testCase.input, `Diffusé ${testCase.input}`];
+
+      for (const variant of variants) {
+        const mockElement = {
+          children: ["", "", { textContent: variant }]
+        };
+
+        const result = parser.parse(mockElement);
+
+        assert.equal(result, testCase.expected);
+      }
+    });
+  }
+});

--- a/src/modules/sorting/sort-by-upload-date/parsers/index.js
+++ b/src/modules/sorting/sort-by-upload-date/parsers/index.js
@@ -1,5 +1,6 @@
 import { EnUploadDateParser } from "./en";
 import { EsUploadDateParser } from "./es";
+import { FrUploadDateParser } from "./fr";
 import { PtUploadDateParser } from "./pt";
 import { ZhHansCnUploadDateParser } from "./zh-Hans-CN";
 import { ZhHantTwUploadDateParser } from "./zh-Hant-TW";
@@ -9,11 +10,14 @@ const UPLOAD_DATE_PARSERS_BY_LOCALE = {
   "en-GB": EnUploadDateParser,
   "en-IN": EnUploadDateParser,
   "en-US": EnUploadDateParser,
-  "es-ES": EsUploadDateParser,
   "es-419": EsUploadDateParser,
+  "es-ES": EsUploadDateParser,
   "es-US": EsUploadDateParser,
-  "pt-PT": PtUploadDateParser,
+  "fr": FrUploadDateParser,
+  "fr-CA": FrUploadDateParser,
+  "fr-FR": FrUploadDateParser,
   "pt-BR": PtUploadDateParser,
+  "pt-PT": PtUploadDateParser,
   "zh-Hans-CN": ZhHansCnUploadDateParser,
   "zh-Hant-TW": ZhHantTwUploadDateParser
 };

--- a/src/modules/sorting/sort-by-views/parsers/fr.js
+++ b/src/modules/sorting/sort-by-views/parsers/fr.js
@@ -1,0 +1,25 @@
+export class FrViewsParser {
+  /** @param {Element} videoInfo */
+  parse(videoInfo) {
+    const viewsElement = videoInfo.firstElementChild;
+    const [value, unit] = viewsElement.textContent
+      .trim()
+      .toLowerCase()
+      .replaceAll(/\s/g, " ")
+      .split(" ");
+
+    const baseViews = parseFloat(value.replace(",", "."));
+
+    if (isNaN(baseViews)) {
+      return 0;
+    }
+
+    if (unit === "k") {
+      return Math.round(baseViews * 1000);
+    } else if (unit === "m") {
+      return Math.round(baseViews * 1_000_000);
+    } else {
+      return Math.round(baseViews);
+    }
+  }
+}

--- a/src/modules/sorting/sort-by-views/parsers/fr.test.js
+++ b/src/modules/sorting/sort-by-views/parsers/fr.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert";
+import { FrViewsParser } from "./fr.js";
+
+test.describe("views-parser/fr", () => {
+  const testCases = [
+    { input: "1 vue", expected: 1 },
+    { input: "420 vues", expected: 420 },
+    { input: "2,4 k vues", expected: 2.4 * 1000 },
+    { input: "870 k vues", expected: 870 * 1000 },
+    { input: "1,4 M de vues", expected: 1.4 * 1_000_000 }
+  ];
+
+  const parser = new FrViewsParser();
+
+  for (const testCase of testCases) {
+    test(testCase.input, () => {
+      const mockElement = {
+        firstElementChild: {
+          textContent: testCase.input
+        }
+      };
+
+      const result = parser.parse(mockElement);
+
+      assert.equal(result, testCase.expected);
+    });
+  }
+});

--- a/src/modules/sorting/sort-by-views/parsers/index.js
+++ b/src/modules/sorting/sort-by-views/parsers/index.js
@@ -1,6 +1,7 @@
 import { EnViewsParser } from "./en";
 import { EnInViewsParser } from "./en-IN";
 import { EsViewsParser } from "./es";
+import { FrViewsParser } from "./fr";
 import { PtViewsParser } from "./pt";
 import { ZhHansCnViewsParser } from "./zh-Hans-CN";
 import { ZhHantTwViewsParser } from "./zh-Hant-TW";
@@ -10,11 +11,14 @@ const VIEWS_PARSERS_BY_LOCALE = {
   "en-GB": EnViewsParser,
   "en-IN": EnInViewsParser,
   "en-US": EnViewsParser,
-  "es-ES": EsViewsParser,
   "es-419": EsViewsParser,
+  "es-ES": EsViewsParser,
   "es-US": EsViewsParser,
-  "pt-PT": PtViewsParser,
+  "fr": FrViewsParser,
+  "fr-CA": FrViewsParser,
+  "fr-FR": FrViewsParser,
   "pt-BR": PtViewsParser,
+  "pt-PT": PtViewsParser,
   "zh-Hans-CN": ZhHansCnViewsParser,
   "zh-Hant-TW": ZhHantTwViewsParser
 };

--- a/src/shared/data/element-selectors.js
+++ b/src/shared/data/element-selectors.js
@@ -11,8 +11,10 @@ export const elementSelectors = {
   },
   playlistMetadata: {
     old: "ytd-playlist-sidebar-renderer #items",
-    new: ".immersive-header-content .metadata-action-bar"
+    new: ".immersive-header-content .metadata-action-bar",
+    youtubePremium: "yt-content-metadata-view-model"
   },
+  playlistDownloadButton: "ytd-download-playlist-button-renderer",
   video: "ytd-playlist-video-renderer",
   playlist: "ytd-playlist-video-list-renderer #contents",
   channelName: ".ytd-channel-name",

--- a/src/shared/data/element-selectors.js
+++ b/src/shared/data/element-selectors.js
@@ -12,9 +12,8 @@ export const elementSelectors = {
   playlistMetadata: {
     old: "ytd-playlist-sidebar-renderer #items",
     new: ".immersive-header-content .metadata-action-bar",
-    youtubePremium: "yt-content-metadata-view-model"
+    youtubePremium: ".yt-flexible-actions-view-model-wiz__action-row"
   },
-  playlistDownloadButton: "ytd-download-playlist-button-renderer",
   video: "ytd-playlist-video-renderer",
   playlist: "ytd-playlist-video-list-renderer #contents",
   channelName: ".ytd-channel-name",


### PR DESCRIPTION
## What's changed

- Updated `addPlaylistSummaryToPage` function
- Created `getPlaylistMetadataElement` function
- Added `try-catch` to `main` to catch & log errors

## Why

- As reported in #55, it appears that if a user has YouTube premium enabled, the playlist overview page changes slightly
  - Download button becomes visible
  - Elements on the page have different identifiers (e.g. classnames, ids, tags)
- The extension will now rely on the presence of a download button to determine whether the user has YouTube premium and accordingly use the correct selector for the metadata element

## Results

### Audit
![image](https://github.com/user-attachments/assets/58c45346-93da-4055-80a6-bb67b5adb22f)
